### PR TITLE
Add escaping to run_and_print

### DIFF
--- a/serverscope.py
+++ b/serverscope.py
@@ -351,7 +351,7 @@ class SpeedtestBenchmark(Benchmark):
 
     def run(self):
         print_(c.GREEN + "Running speedtest benchmark:" + c.RESET)
-        return run_and_print(["python","speedtest.py", "--verbose"])
+        return run_and_print(["python","speedtest.py", "--verbose"]).replace("'",'&#39;')
 
 class DownloadBenchmark(Benchmark):
     code = 'download'


### PR DESCRIPTION
Until we switch back to JSON we need to escape single quotes in benchmark output