### PR TITLE
Fix: fix two minor problems

### DIFF
--- a/install-serverscope.sh
+++ b/install-serverscope.sh
@@ -44,8 +44,10 @@ __get_installer () {
 
 __update_installer () {
     installer="$1"
-    if [ "$installer" == "apt-get" ] || [ "$installer" == "yum" ]; then
+    if [ "$installer" == "apt-get" ]; then
         $installer update -y
+    else if [ "$installer" == "yum" ]; then
+        $installer makecache
     else
         echo "Unknown installer"
     fi

--- a/install-serverscope.sh
+++ b/install-serverscope.sh
@@ -46,7 +46,7 @@ __update_installer () {
     installer="$1"
     if [ "$installer" == "apt-get" ]; then
         $installer update -y
-    else if [ "$installer" == "yum" ]; then
+    elif [ "$installer" == "yum" ]; then
         $installer makecache
     else
         echo "Unknown installer"
@@ -79,7 +79,7 @@ __ensure_python2 () {
 __ensure_pip () {
     which pip > /dev/null
     if [ $? -ne 0 ]; then
-        curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+        curl  https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
         python get-pip.py
         if [ $_cleanup == "yes" ]; then
             rm get-pip.py


### PR DESCRIPTION
This PR aims to fix two minor problems:
1. `yum update` equals to `apt update && apt upgrade -y`, which not only refreshes package index but also upgrades packages. To refresh package index only like `apt update`, we should use `yum makecache`.
2. the `get-pip.py` download from `https://bootstrap.pypa.io/get-pip.py` works on python3.X only. To get the script works on python2.7, we should download `get-pip.py` from `https://bootstrap.pypa.io/pip/2.7/get-pip.py`.